### PR TITLE
bumb pillow 8.2.0 to 8.3.2

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -18,7 +18,7 @@ heroku3
 hachoir==3.1.1
 
 # process(, and resize) images
-Pillow==8.2.0
+Pillow==8.3.2
 
 # SQL DataBase ReQuirements
 psycopg2-binary


### PR DESCRIPTION
This automated pull request fixes a security vulnerability (high severity).
Bumps pillow from 8.2.0 to 8.3.2.
Sourced from pillow's releases.