### PR TITLE
Adapt parse_mode to pyrogram.enums

### DIFF
--- a/pyrobot/plugins/notes/save.py
+++ b/pyrobot/plugins/notes/save.py
@@ -1,4 +1,5 @@
 from pyrogram import Client, filters
+from pyrogram.enums import ParseMode
 from pyrogram.types import InlineKeyboardMarkup
 from pyrobot import COMMAND_HAND_LER, DB_URI, TG_URI
 from pyrobot.helper_functions.cust_p_filters import admin_fliter
@@ -47,7 +48,7 @@ async def save_note(client, message):
             fwded_mesg = await client.send_message(
                 chat_id=TG_URI,
                 text=text,
-                parse_mode="md",
+                parse_mode=ParseMode.MARKDOWN,
                 disable_web_page_preview=True,
                 disable_notification=True,
                 reply_to_message_id=1,
@@ -58,7 +59,7 @@ async def save_note(client, message):
                 chat_id=TG_URI,
                 file_id=content,
                 caption=text,
-                parse_mode="md",
+                parse_mode=ParseMode.MARKDOWN,
                 disable_notification=True,
                 reply_to_message_id=1,
                 reply_markup=reply_markup,

--- a/pyrobot/plugins/notes/save.py
+++ b/pyrobot/plugins/notes/save.py
@@ -1,5 +1,4 @@
 from pyrogram import Client, filters
-from pyrogram.enums import ParseMode
 from pyrogram.types import InlineKeyboardMarkup
 from pyrobot import COMMAND_HAND_LER, DB_URI, TG_URI
 from pyrobot.helper_functions.cust_p_filters import admin_fliter
@@ -48,7 +47,6 @@ async def save_note(client, message):
             fwded_mesg = await client.send_message(
                 chat_id=TG_URI,
                 text=text,
-                parse_mode=ParseMode.MARKDOWN,
                 disable_web_page_preview=True,
                 disable_notification=True,
                 reply_to_message_id=1,
@@ -59,7 +57,6 @@ async def save_note(client, message):
                 chat_id=TG_URI,
                 file_id=content,
                 caption=text,
-                parse_mode=ParseMode.MARKDOWN,
                 disable_notification=True,
                 reply_to_message_id=1,
                 reply_markup=reply_markup,

--- a/pyrobot/plugins/tlifers/save.py
+++ b/pyrobot/plugins/tlifers/save.py
@@ -1,5 +1,6 @@
 import json
 from pyrogram import filters
+from pyrogram.enums import ParseMode
 from pyrogram.types import InlineKeyboardMarkup
 from pyrobot import COMMAND_HAND_LER, TG_URI, TG_IRU_S_M_ID
 from pyrobot.pyrobot import PyroBot
@@ -50,7 +51,7 @@ async def save_filter(client: PyroBot, message):
             fwded_mesg = await client.send_message(
                 chat_id=TG_URI,
                 text=text,
-                parse_mode="md",
+                parse_mode=ParseMode.MARKDOWN,
                 disable_web_page_preview=True,
                 disable_notification=True,
                 reply_to_message_id=1,
@@ -61,7 +62,7 @@ async def save_filter(client: PyroBot, message):
                 chat_id=TG_URI,
                 file_id=content,
                 caption=text,
-                parse_mode="md",
+                parse_mode=ParseMode.MARKDOWN,
                 disable_notification=True,
                 reply_to_message_id=1,
                 reply_markup=reply_markup,

--- a/pyrobot/plugins/tlifers/save.py
+++ b/pyrobot/plugins/tlifers/save.py
@@ -1,6 +1,5 @@
 import json
 from pyrogram import filters
-from pyrogram.enums import ParseMode
 from pyrogram.types import InlineKeyboardMarkup
 from pyrobot import COMMAND_HAND_LER, TG_URI, TG_IRU_S_M_ID
 from pyrobot.pyrobot import PyroBot
@@ -51,7 +50,6 @@ async def save_filter(client: PyroBot, message):
             fwded_mesg = await client.send_message(
                 chat_id=TG_URI,
                 text=text,
-                parse_mode=ParseMode.MARKDOWN,
                 disable_web_page_preview=True,
                 disable_notification=True,
                 reply_to_message_id=1,
@@ -62,7 +60,6 @@ async def save_filter(client: PyroBot, message):
                 chat_id=TG_URI,
                 file_id=content,
                 caption=text,
-                parse_mode=ParseMode.MARKDOWN,
                 disable_notification=True,
                 reply_to_message_id=1,
                 reply_markup=reply_markup,

--- a/pyrobot/plugins/welcome/save.py
+++ b/pyrobot/plugins/welcome/save.py
@@ -1,4 +1,5 @@
 from pyrogram import Client, filters
+from pyrogram.enums import ParseMode
 from pyrogram.types import InlineKeyboardMarkup
 from pyrobot import COMMAND_HAND_LER, DB_URI, TG_URI
 from pyrobot.helper_functions.cust_p_filters import admin_fliter
@@ -42,7 +43,7 @@ async def save_note(client, message):
             fwded_mesg = await client.send_message(
                 chat_id=TG_URI,
                 text=text,
-                parse_mode="md",
+                parse_mode=ParseMode.MARKDOWN,
                 disable_web_page_preview=True,
                 disable_notification=True,
                 reply_to_message_id=1,
@@ -53,7 +54,7 @@ async def save_note(client, message):
                 chat_id=TG_URI,
                 file_id=content,
                 caption=text,
-                parse_mode="md",
+                parse_mode=ParseMode.MARKDOWN,
                 disable_notification=True,
                 reply_to_message_id=1,
                 reply_markup=reply_markup,

--- a/pyrobot/plugins/welcome/save.py
+++ b/pyrobot/plugins/welcome/save.py
@@ -1,5 +1,4 @@
 from pyrogram import Client, filters
-from pyrogram.enums import ParseMode
 from pyrogram.types import InlineKeyboardMarkup
 from pyrobot import COMMAND_HAND_LER, DB_URI, TG_URI
 from pyrobot.helper_functions.cust_p_filters import admin_fliter
@@ -43,7 +42,6 @@ async def save_note(client, message):
             fwded_mesg = await client.send_message(
                 chat_id=TG_URI,
                 text=text,
-                parse_mode=ParseMode.MARKDOWN,
                 disable_web_page_preview=True,
                 disable_notification=True,
                 reply_to_message_id=1,
@@ -54,7 +52,6 @@ async def save_note(client, message):
                 chat_id=TG_URI,
                 file_id=content,
                 caption=text,
-                parse_mode=ParseMode.MARKDOWN,
                 disable_notification=True,
                 reply_to_message_id=1,
                 reply_markup=reply_markup,


### PR DESCRIPTION
`parse_mode="md"` This method is enclosed in "`enums`" with pyrogram 2.0, so I adapted it accordingly

**_UPDATE_**
I'm made a correction because the default parse_mode is HTML